### PR TITLE
Fixes URL encoding issue

### DIFF
--- a/models/v3/msgs/msgs.go
+++ b/models/v3/msgs/msgs.go
@@ -142,7 +142,6 @@ func (n Notifications) dataToJSON() ([]byte, error) {
 // SendEvent converts the notification to an event and sends it to the ARN service.
 // Do not call this function directly, use methods on the Client instead.
 func (n Notifications) SendEvent(hc *http.Client, store *storage.Client) error {
-
 	if len(n.Data) == 0 {
 		return errors.New("no data to send")
 	}
@@ -173,7 +172,8 @@ func (n Notifications) SendEvent(hc *http.Client, store *storage.Client) error {
 	}
 
 	// Tell the service (via HTTP) where to find the blob.
-	event.Data.ResourcesBlobInfo.BlobURI = u
+	event.Data.ResourcesBlobInfo.BlobURI = u.String()
+	event.Data.ResourcesBlobInfo.BlobSize = int64(len(dataJSON))
 	return n.sendHTTP(hc, event)
 }
 

--- a/models/v3/schema/types/types.go
+++ b/models/v3/schema/types/types.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -132,14 +131,14 @@ func (d Data) Validate() error {
 type ResourcesBlobInfo struct {
 	// BlobURI is the the Blob uri with SAS (shared access signature) for the reader to
 	// be able to have access to download the data and parse into NotificationResourceData objects.
-	BlobURI *url.URL `json:"blobUri"`
+	BlobURI string `json:"blobUri"`
 	// BlobSize is the size in bytes of the blob payload content.
 	BlobSize int64 `json:"blobSize"`
 }
 
 // Validate validates the ResourcesBlobInfo.
 func (r *ResourcesBlobInfo) Validate() error {
-	if r.BlobURI == nil {
+	if r.BlobURI == "" {
 		return errors.New(".ResourcesBlobInfo.BlobURI is required")
 	}
 	if r.BlobSize == 0 {


### PR DESCRIPTION
Apparently url.URL doesn't have any of the marshallers needed for JSON encoding.  Tisk, tisk.

Also fixed the upload size which wasn't populated.