### PR TITLE
Prevent different objects from being in the same notification

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,8 @@
 /*
 Package client provides a client for interacting with the ARN service.
 
-NOTE: AKS engineers: It is highly unlikely that you should be using this package. Please contact AKS runtime eng. for more information.
+NOTE: AKS engineers: If you trying to send node/pod/etc information, you are likely duplicating work that is already
+done. Please contact AKS runtime engineering (under the node team) for more information.
 
 Allows you to run in two modes:
 - Synchronous: Use Notify() to send a notification and block until it is sent.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/arn-sdk
 
-go 1.22.4
+go 1.23.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.13.0

--- a/models/internal/private/private.go
+++ b/models/internal/private/private.go
@@ -42,8 +42,8 @@ type Senders interface {
 	// SendEvent sends the event to the ARN service. It is also responsible for
 	// calling Event.Validate() before sending the event.
 	SendEvent(*http.Client, *storage.Client) error
-	// SendPromise sends "e" on the promise to the notification. If the promise is nil,
-	// it will send on the backup channel (should be client.Errors()).
+	// SendPromise sends "e" on the promise to the notification. If the promise is nil on the notification,
+	// this call will send on the backup channel (the backup channel should be client.Errors()).
 	SendPromise(e error, backupCh chan error)
 }
 

--- a/models/v3/msgs/msgs.go
+++ b/models/v3/msgs/msgs.go
@@ -42,6 +42,8 @@ type Notifications struct {
 	ResourceLocation string
 	// PublisherInfo is the Namespace of the publisher sending the data of this notification, for example Microsoft.Resources is be the publisherInfo for ARM.
 	PublisherInfo string
+	// AdditionalBatchProperties can contain the sdkversion, batchsize, subscription partition tag etc.
+	AdditionalBatchProperties map[string]any
 
 	// Data is the data to send in the notification.
 	Data []types.NotificationResource
@@ -214,11 +216,12 @@ func (n Notifications) toEvent() ([]byte, envelope.Event, error) {
 		return dataJSON, envelope.Event{
 			EventMeta: meta,
 			Data: types.Data{
-				Data:               dataJSON,
-				ResourcesContainer: types.RCInline,
-				ResourceLocation:   n.ResourceLocation,
-				PublisherInfo:      n.PublisherInfo,
-				Resources:          n.Data,
+				Data:                      dataJSON,
+				AdditionalBatchProperties: n.AdditionalBatchProperties,
+				ResourcesContainer:        types.RCInline,
+				ResourceLocation:          n.ResourceLocation,
+				PublisherInfo:             n.PublisherInfo,
+				Resources:                 n.Data,
 			},
 		}, nil
 	}

--- a/models/v3/msgs/subject.go
+++ b/models/v3/msgs/subject.go
@@ -23,6 +23,25 @@ func asSlice(rid *arm.ResourceID) (rids []*arm.ResourceID) {
 	return rids
 }
 
+// subject returns in string form the maximal arm.ResourceID which is a shared prefix of all of the resources in res.  At least one
+// *types.NotificationResource must be passed to this function.
+func subject(res []types.NotificationResource) string {
+	if len(res) == 0 {
+		return ""
+	}
+	max := asSlice(res[0].ArmResource.ResourceID())
+
+	for i := 1; i < len(res); i++ {
+		max = maxSharedPrefix(max, asSlice(res[i].ArmResource.ResourceID()))
+	}
+
+	if len(max) <= 1 { // only the tenant-level scope was shared or no scopes were shared
+		return "/"
+	}
+
+	return max[0].String()
+}
+
 // maxSharedPrefix returns in slice form the maximal arm.ResourceID which is a shared prefix of a and b.
 func maxSharedPrefix(a, b []*arm.ResourceID) (results []*arm.ResourceID) {
 	// We can find the maximal arm.ResourceID which is a shared prefix of a and b by walking the slices backwards comparing their scopes.
@@ -41,23 +60,4 @@ func maxSharedPrefix(a, b []*arm.ResourceID) (results []*arm.ResourceID) {
 	slices.Reverse(results)
 
 	return results
-}
-
-// subject returns in string form the maximal arm.ResourceID which is a shared prefix of all of the resources in res.  At least one
-// *types.ResourceEvent must be passed to this function.
-func subject(res []types.NotificationResource) string {
-	if len(res) == 0 {
-		return ""
-	}
-	max := asSlice(res[0].ArmResource.ResourceID())
-
-	for i := 1; i < len(res); i++ {
-		max = maxSharedPrefix(max, asSlice(res[i].ArmResource.ResourceID()))
-	}
-
-	if len(max) <= 1 { // only the tenant-level scope was shared or no scopes were shared
-		return "/"
-	}
-
-	return max[0].String()
 }


### PR DESCRIPTION
This change prevents objects of different types from being in the same notification.

Also exposes AdditionalBatchProperties for the user.