### PR TITLE
Changes how additionalBatchProperties work

### DIFF
--- a/.github/codeql-analysis.yml
+++ b/.github/codeql-analysis.yml
@@ -1,0 +1,84 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main]
+  schedule:
+    - cron: "0 14 * * 2"
+  workflow_dispatch: # This allows manual triggering of the workflow
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    permissions:
+      actions: read # for github/codeql-action/init to get workflow details
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/autobuild to send a status report
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+        language: ["go"]
+        # Learn more...
+        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+
+      #- run: |
+      #   make bootstrap
+      #   make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6

--- a/.github/go.yml
+++ b/.github/go.yml
@@ -1,0 +1,45 @@
+name: Go
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 14 * * 2"
+  workflow_dispatch: # This allows manual triggering of the workflow
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: 1.22.4
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+  govulncheck_job:
+    name: Run govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: 1.22.4
+          go-package: ./...

--- a/models/v3/schema/types/types.go
+++ b/models/v3/schema/types/types.go
@@ -29,7 +29,9 @@ const (
 	StatusCode = "OK"
 )
 
-// Data represents the data of the event. There are two ways to send the data:
+// Data represents the data of the event. THIS IS NOT USED DIRECTLY, BUT INSTEAD IS CREATED BY msgs.Notification.
+// THIS IS PUBLIC TO ALLOW FOR MARSHALING. NOT ALL FIELDS ARE CURRENTLY EXPOSED.
+// There are two ways to send the data:
 // 1. Inline: The resources being are included in the Resources field.
 // 2. Blob: The resources are stored in a blob and the information about the blob is included in ResourcesBlobInfo.
 // The ResourcesContainer field is used to determine if the resources are inline or in a blob.
@@ -40,7 +42,7 @@ type Data struct {
 	// This is a JSON serialized version of the Resources field.
 	Data json.RawMessage `json:"resources"`
 	// AdditionalBatchProperties can contain the sdkversion, batchsize, subscription partition tag etc.
-	AdditionalBatchProperties map[string]any `json:"additionalBatchProperties,omitzero"`
+	AdditionalBatchProperties AdditionalBatchProperties `json:"additionalBatchProperties"`
 	// ResourcesBlobInfo is the information about the storage blob used to store the payload of resources included in this notification.
 	// Populated only when a blob is used, in which case ResourcesContainer is set to Blob.
 	ResourcesBlobInfo ResourcesBlobInfo `json:"resourcesBlobInfo,omitzero"`
@@ -145,6 +147,23 @@ func (d Data) Validate() error {
 	}
 
 	return nil
+}
+
+// AdditionalBatchProperties is the additional properties that can be set on a batch of notifications.
+type AdditionalBatchProperties struct {
+	// BatchCorrelationID is a unique identifier for the batch of notifications. This can be used by
+	// ARN or ARG in traces. This is a GUID. Optional.
+	BatchCorrelationID string `json:"batchCorrelationId"`
+	// SDKVersion is the version of the SDK that is sending the notification.
+	// This is automaticallly set by the SDK.
+	SDKVersion string `json:"sdkVersion"`
+	// BatchSize is the number of resources in the batch. These may be inline or in a blob. This is
+	// automatically set by the SDK.
+	BatchSize uint16 `json:"batchSize"`
+	// Others is a map of additional properties that are provided by the user. These should not
+	// include keys that are already defined in the struct. These entries are inlined into the
+	// object when serialized.
+	Others map[string]any `json:",inline"`
 }
 
 // ResourcesBlobInfo is the information about the storage blob used to store the payload of resources

--- a/models/version/version.go
+++ b/models/version/version.go
@@ -1,6 +1,10 @@
 // Package version provides the schema version of the SDK.
 package version
 
+import (
+	"fmt"
+)
+
 // Schema is the schema version of the API.
 // The Go SDK only supports from schema version 3.
 type Schema string
@@ -9,3 +13,26 @@ const (
 	// V3 is the schema version 3.
 	V3 Schema = "3.0"
 )
+
+// SDK contains the version information of the SDK.
+var SDK SDKVersion = SDKVersion{
+	Version: "0.1.0",
+}
+
+// SDKVersion describes the version information of the API.
+type SDKVersion struct {
+	// Version contains the version of the API, aka v1.2.3 .
+	Version string
+}
+
+func (s SDKVersion) String() string {
+	return "v" + s.Version
+}
+
+// AsARNFormat returns the API version in a format that ARN understands.
+func (s SDKVersion) AsARNFormat() string {
+	if s.Version != "" {
+		return fmt.Sprintf("golang@%s", s.Version)
+	}
+	return "golang@unknown"
+}


### PR DESCRIPTION
additionalBatchProperties was a map[string]any, however....

There are several properties here that should always be set and are static values + operator added.  So I made this a struct with an embeddable map that inlines its keys when it marshals.  

We now calculate the batchSize and sdkVersion automatically for this new struct.

Also includes some github standard actions.