### PR TITLE
Changes compression to use zlib headers instead of straight deflate, adds publisherinfo header

### DIFF
--- a/internal/conn/http/deflate_test.go
+++ b/internal/conn/http/deflate_test.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/zlib"
 	"context"
 	"fmt"
 	"io"
@@ -38,7 +38,10 @@ func (h *httpHandler) handleDeflateRequest(w http.ResponseWriter, r *http.Reques
 	if r.Header.Get("Content-Encoding") == "deflate" {
 		h.countA.Add(1)
 		// Wrap the request body in a flate.Reader to decompress it
-		deflateReader := flate.NewReader(r.Body)
+		deflateReader, err := zlib.NewReader(r.Body)
+		if err != nil {
+			panic(err)
+		}
 		defer deflateReader.Close()
 
 		// Read the decompressed data

--- a/internal/conn/http/http_test.go
+++ b/internal/conn/http/http_test.go
@@ -4,17 +4,23 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strconv"
 	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestSetup(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
-		name            string
-		endpoint        string
-		body            []byte
-		wantErr         bool
-		wantBody        string
-		wantContentType string
+		name        string
+		endpoint    string
+		headers     []string
+		body        []byte
+		wantErr     bool
+		wantBody    string
+		wantHeaders map[string][]string
 	}{
 		{
 			name:     "empty body",
@@ -28,18 +34,33 @@ func TestSetup(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:            "good endpoint",
-			endpoint:        "http://localhost:8080",
-			body:            []byte("hello"),
-			wantBody:        "hello",
-			wantContentType: "application/json",
+			name:     "bad headers",
+			endpoint: "http://localhost:8080",
+			headers:  []string{"onlyOneKeyAndNoValue"},
+			wantErr:  true,
+		},
+		{
+			name:     "good endpoint",
+			endpoint: "http://localhost:8080",
+			body:     []byte("hello"),
+			wantBody: "hello",
+		},
+		{
+			name:     "good endpoint with headers",
+			endpoint: "http://localhost:8080",
+			headers:  []string{"publisherinfo", "whatever"},
+			body:     []byte("hello"),
+			wantBody: "hello",
+			wantHeaders: map[string][]string{
+				"publisherinfo": []string{"whatever"},
+			},
 		},
 	}
 
 	c := &Client{}
 	for _, test := range tests {
 		c.endpoint = test.endpoint
-		req, err := c.setup(context.Background(), bytes.NewReader(test.body))
+		req, err := c.setup(context.Background(), bytes.NewReader(test.body), test.headers)
 		switch {
 		case test.wantErr && err == nil:
 			t.Errorf("TestSetup(%s): got err == nil, want err != nil", test.name)
@@ -53,13 +74,27 @@ func TestSetup(t *testing.T) {
 
 		gotBody, err := io.ReadAll(req.Body())
 		if err != nil {
-			t.Fatalf("req.Body: got err == %v, want err == nil", err)
+			t.Fatalf("TestSetup(%s): req.Body: got err == %v, want err == nil", test.name, err)
 		}
 		if string(gotBody) != "hello" {
-			t.Fatalf("req.Body: got %s, want %s", gotBody, "hello")
+			t.Fatalf("TestSetup(%s): req.Body: got %s, want %s", test.name, gotBody, "hello")
 		}
-		if req.Raw().Header.Get("Content-Type") != "application/json" {
-			t.Fatalf("req.Raw().Header.Get(Content-Type): got %s, want %s", req.Raw().Header.Get("Content-Type"), "application/json")
+
+		if test.wantHeaders == nil {
+			test.wantHeaders = map[string][]string{}
+		}
+		test.wantHeaders["Accept"] = []string{"application/json"}
+		test.wantHeaders["Content-Type"] = []string{"application/json"}
+		test.wantHeaders["Content-Length"] = []string{strconv.Itoa(len(test.body))}
+		if len(test.wantHeaders) != len(req.Raw().Header) {
+			diff := pretty.Compare(test.wantHeaders, req.Raw().Header)
+			t.Fatalf("TestSetup(%s): -want/+got:\n%s", test.name, diff)
+			//t.Fatalf("TestSetup(%s): len(req.Raw().Header): got %d, want %d", test.name, len(req.Raw().Header), len(test.wantHeaders))
+		}
+		for k, v := range test.wantHeaders {
+			if req.Raw().Header.Get(k) != v[0] {
+				t.Fatalf("TestSetup(%s): req.Raw().Header.Get(%s): got %s, want %s", test.name, k, req.Raw().Header.Get(k), v)
+			}
 		}
 	}
 }

--- a/models/internal/private/private.go
+++ b/models/internal/private/private.go
@@ -33,6 +33,8 @@ type Attrs interface {
 	DataCount() int
 	// Version returns the schema version of the API.
 	Version() version.Schema
+	// GetPublisherInfo returns the publisher information for the notification.
+	GetPublisherInfo() string
 }
 
 // Senders is an interface that must be implemented by all notification types across models.


### PR DESCRIPTION
We were using straight deflate instead of zlib headers.  This changes that.

Also, arn specifies that we should promote the PublisherInfo from the message into the http header.  So we are doing that too.