### PR TITLE
Changing the containers to be created to 1 hour

### DIFF
--- a/internal/conn/storage/storage.go
+++ b/internal/conn/storage/storage.go
@@ -87,8 +87,8 @@ var contRE = regexp.MustCompile(`^[a-z0-9-]{1,41}$`)
 
 // WithContainerExt sets a name extension for a blob container. This can be useful for
 // doing discovery of containers that are created by a particular client.
-// Names are in the format "arm-ext-nt-YYYY-MM-DD". This will cause the client to create
-// "arm-ext-nt-[ext]-YYYY-MM-DD". Note characters must be letters, numbers, or hyphens.
+// Names are in the format "arm-ext-nt-YYYY-MM-DD-HH". This will cause the client to create
+// "arm-ext-nt-[ext]-YYYY-MM-DD-HH". Note characters must be letters, numbers, or hyphens.
 // Any letters will be automatically lowercased. The ext cannot be more than 41 characters.
 func WithContainerExt(ext string) Option {
 	return func(c *Client) error {
@@ -174,9 +174,9 @@ func (c *Client) Upload(ctx context.Context, id string, b []byte) (*url.URL, err
 	}
 
 	if c.contExt == "" {
-		cName = fmt.Sprintf("%s-%s", contPrefix, c.now().UTC().Format(time.DateOnly))
+		cName = fmt.Sprintf("%s-%s-%d", contPrefix, c.now().UTC().Format(time.DateOnly), time.Now().Hour())
 	} else {
-		cName = fmt.Sprintf("%s-%s-%s", contPrefix, c.contExt, c.now().UTC().Format(time.DateOnly))
+		cName = fmt.Sprintf("%s-%s-%s-%d", contPrefix, c.contExt, c.now().UTC().Format(time.DateOnly), time.Now().Hour())
 	}
 	bName := id + ".txt"
 

--- a/internal/conn/storage/storage.go
+++ b/internal/conn/storage/storage.go
@@ -166,18 +166,13 @@ func (c *Client) Close() {
 
 // Upload uploads bytes to a blob named id in today's container.  It returns a SAS link enabling the blob to be read.
 func (c *Client) Upload(ctx context.Context, id string, b []byte) (*url.URL, error) {
-	const contPrefix = "arm-ext-nt"
 	var cName string
 
 	if c.fakeUploader != nil {
 		return c.fakeUploader.Upload(ctx, id, b)
 	}
 
-	if c.contExt == "" {
-		cName = fmt.Sprintf("%s-%s-%d", contPrefix, c.now().UTC().Format(time.DateOnly), time.Now().Hour())
-	} else {
-		cName = fmt.Sprintf("%s-%s-%s-%d", contPrefix, c.contExt, c.now().UTC().Format(time.DateOnly), time.Now().Hour())
-	}
+	cName = c.cName()
 	bName := id + ".txt"
 
 	cClient := c.cli.NewContainerClient(cName)
@@ -199,6 +194,15 @@ func (c *Client) Upload(ctx context.Context, id string, b []byte) (*url.URL, err
 	}
 
 	return c.upload(ctx, args)
+}
+
+// cName returns the container name to be used.
+func (c *Client) cName() string {
+	const contPrefix = "arm-ext-nt"
+	if c.contExt == "" {
+		return fmt.Sprintf("%s-%s-%d", contPrefix, c.now().UTC().Format(time.DateOnly), c.now().Hour())
+	}
+	return fmt.Sprintf("%s-%s-%s-%d", contPrefix, c.contExt, c.now().UTC().Format(time.DateOnly), c.now().Hour())
 }
 
 // uploadBuffer is an interface for uploading a buffer. Implemented by *blockblob.BlockBlobClient.

--- a/internal/conn/storage/storage_test.go
+++ b/internal/conn/storage/storage_test.go
@@ -246,3 +246,45 @@ func TestHandleUploadErr(t *testing.T) {
 	}
 
 }
+
+func TestCName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		now      func() time.Time
+		contExt  string
+		expected string
+	}{
+		{
+			name: "Default container name without extension",
+			now: func() time.Time {
+				return time.Date(2023, 10, 1, 15, 0, 0, 0, time.UTC)
+			},
+			contExt:  "",
+			expected: "arm-ext-nt-2023-10-01-15",
+		},
+		{
+			name: "Container name with extension",
+			now: func() time.Time {
+				return time.Date(2023, 10, 1, 15, 0, 0, 0, time.UTC)
+			},
+			contExt:  "my-extension",
+			expected: "arm-ext-nt-my-extension-2023-10-01-15",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{
+				now:     test.now,
+				contExt: test.contExt,
+			}
+
+			got := client.cName()
+			if got != test.expected {
+				t.Errorf("TestCName(%s): got %s, want %s", test.name, got, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This moves the container creation to 1 hour instead of 1 day.  This is going to let us delete containers in larger chunks instead of by files.  This then lowers cloud billing.

This will necessitate a minor revision upgrade because we are changing the naming format of the containers.